### PR TITLE
Fix exception in 'stacker build --dump' when targets are defined

### DIFF
--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -335,6 +335,10 @@ class Plan(object):
             os.makedirs(directory)
 
         def walk_func(step):
+            # Skip targets
+            if not hasattr(step.stack, "blueprint"):
+                return True
+
             step.stack.resolve(
                 context=context,
                 provider=provider,


### PR DESCRIPTION
Fixes this exception:
```
$ stacker build --dump out stacks.yaml
...
Traceback (most recent call last):
  File "bin/stacker", line 10, in <module>
    args.run(args)
  File "stacker/stacker/commands/stacker/build.py", line 55, in run
    action.execute(concurrency=options.max_parallel,
  File "stacker/stacker/actions/base.py", line 206, in execute
    self.run(*args, **kwargs)
  File "stacker/stacker/actions/build.py", line 434, in run
    plan.dump(directory=dump, context=self.context,
  File "stacker/stacker/plan.py", line 360, in dump
    return self.graph.walk(walk, walk_func)
  File "stacker/stacker/plan.py", line 270, in walk
    return walker(self.dag, fn)
  File "stacker/stacker/dag/__init__.py", line 397, in walk
    return dag.walk(walk_func)
  File "stacker/stacker/dag/__init__.py", line 167, in walk
    walk_func(n)
  File "stacker/stacker/plan.py", line 268, in fn
    return walk_func(step)
  File "stacker/stacker/plan.py", line 342, in walk_func
    step.stack.resolve(
AttributeError: 'Target' object has no attribute 'resolve'
```