### PR TITLE
[CLOUD-197] fix syntax issue with boto3 version boundaries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = [
     "future",
     "troposphere>=1.9.0",
     'botocore>=1.12.111',  # matching boto3 requirement
-    "boto3>=1.9.111<2.0",
+    "boto3>=1.9.111,<2.0",
     "PyYAML>=3.13b1",
     "awacs>=0.6.0",
     "gitpython>=2.0,<3.0",


### PR DESCRIPTION
## Purpose
Seeing errors like https://app.circleci.com/pipelines/github/datadotworld/stacker-blueprints/4039/workflows/59b9aaee-f33b-4082-b38f-3e27a9fce133/jobs/6971
```× python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [7 lines of output]
      /usr/local/lib/python3.9/site-packages/setuptools/dist.py:775: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
        warnings.warn(
      /usr/local/lib/python3.9/site-packages/setuptools/installer.py:27: SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
        warnings.warn(
      error in stacker setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
          boto3>=1.9.111<2.0
               ~~~~~~~~~^
      [end of output]

This had [already been adjusted in original stacker,](https://github.com/cloudtools/stacker/commit/72eb1b0fc8afd3456ea48e8a140fcfca56a4036d) which we forked from, so applying the same patch here.

## Ticket
https://dataworld.atlassian.net/browse/CLOUD-199