### PR TITLE
Drop support for Python 2.7-3.6 and upgrade to recent dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       - image: circleci/python:3.7
     steps:
       - checkout
-      - run: sudo pip install flake8 codecov pep8-naming flake8-future-import
+      - run: sudo pip install flake8 codecov pep8-naming
       - run: sudo python setup.py install
       - run: flake8 --version
       - run: sudo make lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,44 +5,44 @@ workflows:
   test-all:
     jobs:
       - lint
-      - unit-test-27:
-          requires:
-            - lint
-      - functional-test-27:
-          requires:
-            - unit-test-27
-      - unit-test-35:
-          requires:
-            - lint
-      - functional-test-35:
-          requires:
-            - unit-test-35
-            - functional-test-27
-      - unit-test-36:
-          requires:
-            - lint
-      - functional-test-36:
-          requires:
-            - unit-test-36
-            - functional-test-35
       - unit-test-37:
           requires:
             - lint
       - functional-test-37:
           requires:
             - unit-test-37
-            - functional-test-36
+      - unit-test-38:
+          requires:
+            - lint
+      - functional-test-38:
+          requires:
+            - unit-test-38
+            - functional-test-37
+      - unit-test-39:
+          requires:
+            - lint
+      - functional-test-39:
+          requires:
+            - unit-test-39
+            - functional-test-38
+      - unit-test-310:
+          requires:
+            - lint
+      - functional-test-310:
+          requires:
+            - unit-test-310
+            - functional-test-39
       - cleanup-functional-buckets:
           requires:
-            - functional-test-27
-            - functional-test-35
-            - functional-test-36
             - functional-test-37
+            - functional-test-38
+            - functional-test-39
+            - functional-test-310
 
 jobs:
   lint:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     steps:
       - checkout
       - run: sudo pip install flake8 codecov pep8-naming flake8-future-import
@@ -50,32 +50,32 @@ jobs:
       - run: flake8 --version
       - run: sudo make lint
 
-  unit-test-27:
+  unit-test-37:
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.7
     steps: &unit_test_steps
       - checkout
       - run: sudo python setup.py install
       - run: sudo make test-unit
 
-  unit-test-35:
+  unit-test-38:
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.8
     steps: *unit_test_steps
 
-  unit-test-36:
+  unit-test-39:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.9
     steps: *unit_test_steps
 
-  unit-test-37:
+  unit-test-310:
+    docker:
+      - image: circleci/python:3.10
+    steps: *unit_test_steps
+
+  functional-test-37:
     docker:
       - image: circleci/python:3.7
-    steps: *unit_test_steps
-
-  functional-test-27:
-    docker:
-      - image: circleci/python:2.7
     steps: &functional_test_steps
       - checkout
       - run:
@@ -94,24 +94,24 @@ jobs:
             export STACKER_ROLE=arn:aws:iam::459170252436:role/cloudtools-functional-tests-sta-FunctionalTestRole-1M9HFJ9VQVMFX
             sudo -E make test-functional
 
-  functional-test-35:
+  functional-test-38:
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.8
     steps: *functional_test_steps
 
-  functional-test-36:
+  functional-test-39:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.9
     steps: *functional_test_steps
 
-  functional-test-37:
+  functional-test-310:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.10
     steps: *functional_test_steps
 
   cleanup-functional-buckets:
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.7
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ build:
 	docker build -t remind101/stacker .
 
 lint:
-	flake8 --ignore E402,W503,W504,W605 --exclude stacker/tests/ stacker
-	flake8 --ignore E402,N802,W605 stacker/tests # ignore setUp naming
+	flake8 --ignore E402,W503,W504,W605,N818 --exclude stacker/tests/ stacker
+	flake8 --ignore E402,N802,W605,N818 stacker/tests # ignore setUp naming
 
 test-unit: clean
 	python setup.py test

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ build:
 	docker build -t remind101/stacker .
 
 lint:
-	flake8 --ignore FI50,FI51,FI53,FI14,E402,W503,W504,W605 --exclude stacker/tests/ stacker
-	flake8 --ignore FI50,FI51,FI53,FI14,E402,N802,W605 stacker/tests # ignore setUp naming
+	flake8 --ignore E402,W503,W504,W605 --exclude stacker/tests/ stacker
+	flake8 --ignore E402,N802,W605 stacker/tests # ignore setUp naming
 
 test-unit: clean
 	python setup.py test

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ build:
 	docker build -t remind101/stacker .
 
 lint:
-	flake8 --require-code --min-version=2.7 --ignore FI50,FI51,FI53,FI14,E402,W503,W504,W605 --exclude stacker/tests/ stacker
-	flake8 --require-code --min-version=2.7 --ignore FI50,FI51,FI53,FI14,E402,N802,W605 stacker/tests # ignore setUp naming
+	flake8 --ignore FI50,FI51,FI53,FI14,E402,W503,W504,W605 --exclude stacker/tests/ stacker
+	flake8 --ignore FI50,FI51,FI53,FI14,E402,N802,W605 stacker/tests # ignore setUp naming
 
 test-unit: clean
 	python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,7 @@ both in development, staging, and production without any major issues.
 Requirements
 ============
 
-* Python 2.7
-* Python 3.5+
+* Python 3.7+
 
 Stacker Command
 ===============
@@ -60,7 +59,7 @@ Here are some examples:
 
   ``destroy``:
     tears down your stacks
-    
+
   ``diff``:
     compares your currently deployed stack templates to your config files
 
@@ -76,26 +75,26 @@ Getting Started
 ``stacker_cookiecutter``: https://github.com/cloudtools/stacker_cookiecutter
 
   We recommend creating your base `stacker` project using ``stacker_cookiecutter``.
-  This tool will install all the needed dependencies and created the project 
+  This tool will install all the needed dependencies and created the project
   directory structure and files. The resulting files are well documented
   with comments to explain their purpose and examples on how to extend.
-  
+
 ``stacker_blueprints``: https://github.com/cloudtools/stacker_blueprints
 
   This repository holds working examples of ``stacker`` blueprints.
-  Each blueprint works in isolation and may be referenced, extended, or 
+  Each blueprint works in isolation and may be referenced, extended, or
   copied into your project files. The blueprints are written in Python
   and use the troposphere_ library.
-  
+
 ``stacker reference documentation``:
-  
+
   We document all functionality and features of stacker in our extensive
   reference documentation located at readthedocs_.
 
 ``AWS OSS Blog``: https://aws.amazon.com/blogs/opensource/using-aws-codepipeline-and-open-source-tools-for-at-scale-infrastructure-deployment/
 
   The AWS OSS Blog has a getting started guide using stacker with AWS CodePipeline.
-  
+
 
 Docker
 ======

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-troposphere>=1.9.0
+troposphere>=3.0.0
 botocore>=1.12.111
 boto3>=1.9.111,<2.0
 PyYAML>=3.13b1

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ PyYAML>=3.13b1
 awacs>=0.6.0
 gitpython>=3.0
 jinja2>=2.7
-schematics>=2.0.1,<2.1.0
+schematics>=2.1.0
 formic2
 python-dateutil>=2.0,<3.0
 MarkupSafe>=2

--- a/requirements.in
+++ b/requirements.in
@@ -1,0 +1,15 @@
+troposphere>=1.9.0
+botocore>=1.12.111
+boto3>=1.9.111,<2.0
+PyYAML>=3.13b1
+awacs>=0.6.0
+gitpython>=3.0
+jinja2>=2.7
+schematics>=2.0.1,<2.1.0
+formic2
+python-dateutil>=2.0,<3.0
+MarkupSafe>=2
+more-itertools
+rsa>=4.7
+python-jose
+future

--- a/setup.py
+++ b/setup.py
@@ -5,34 +5,15 @@ VERSION = "1.7.2"
 
 src_dir = os.path.dirname(__file__)
 
-install_requires = [
-    "future",
-    "troposphere>=1.9.0",
-    'botocore>=1.12.111',  # matching boto3 requirement
-    "boto3>=1.9.111,<2.0",
-    "PyYAML>=3.13b1",
-    "awacs>=0.6.0",
-    "gitpython>=2.0,<3.0",
-    "jinja2>=2.7,<3.0a",
-    "schematics>=2.0.1,<2.1.0",
-    "formic2",
-    "python-dateutil>=2.0,<3.0",
-    "MarkupSafe<2.0", # 2.0 dropped python 2.7, 3.5 support - temporary
-    "more-itertools<6.0.0", # 6.0.0 dropped python 2.7 support - temporary
-    "rsa==4.5", # 4.6 dropped python 2.7 support - temporary
-    "python-jose<3.2.0", # 3.2.0 dropped python 2.7 support - temporary
-]
+def get_install_requirements(path):
+    content = open(os.path.join(os.path.dirname(__file__), path)).read()
+    return [req for req in content.split("\n") if req != "" and not req.startswith("#")]
+
+install_requires = get_install_requirements("requirements.in")
 
 setup_requires = ['pytest-runner']
 
-tests_require = [
-    "pytest~=4.3",
-    "pytest-cov~=2.6",
-    "mock~=2.0",
-    "moto[awslambda]~=1.3.16",
-    "testfixtures~=4.10.0",
-    "flake8-future-import",
-]
+tests_require = get_install_requirements("test-requirements.in")
 
 scripts = [
     "scripts/compare_env",
@@ -68,8 +49,9 @@ if __name__ == "__main__":
             "Development Status :: 5 - Production/Stable",
             "Environment :: Console",
             "License :: OSI Approved :: BSD License",
-            "Programming Language :: Python :: 2.7",
-            "Programming Language :: Python :: 3.5",
-            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
         ],
     )

--- a/stacker/__init__.py
+++ b/stacker/__init__.py
@@ -1,5 +1,2 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 __version__ = "1.7.2"

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import object
 import os
 import sys
 import logging

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import logging
 
 from .base import BaseAction, plan, build_walker

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import logging
 
 from .base import BaseAction, plan, build_walker

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -1,8 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import str
-from builtins import object
 import logging
 from operator import attrgetter
 

--- a/stacker/actions/graph.py
+++ b/stacker/actions/graph.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import logging
 import sys
 import json

--- a/stacker/actions/info.py
+++ b/stacker/actions/info.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import logging
 
 from .base import BaseAction

--- a/stacker/awscli_yamlhelper.py
+++ b/stacker/awscli_yamlhelper.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Copyright 2012-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -534,7 +534,7 @@ class Blueprint(object):
                 template.
 
         """
-        self.template.add_description(description)
+        self.template.set_description(description)
 
     def add_output(self, name, value):
         """Simple helper for adding outputs.

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -1,9 +1,4 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import str
 from past.builtins import basestring
-from builtins import object
 import copy
 import hashlib
 import logging

--- a/stacker/blueprints/raw.py
+++ b/stacker/blueprints/raw.py
@@ -1,7 +1,4 @@
 """Blueprint representing raw template module."""
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 import hashlib
 import json

--- a/stacker/blueprints/testutil.py
+++ b/stacker/blueprints/testutil.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import difflib
 import json
 import unittest

--- a/stacker/blueprints/variables/types.py
+++ b/stacker/blueprints/variables/types.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import object
 
 
 class TroposphereType(object):

--- a/stacker/commands/__init__.py
+++ b/stacker/commands/__init__.py
@@ -1,4 +1,1 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from .stacker import Stacker  # NOQA

--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import logging
 
 from .build import Build

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -1,7 +1,7 @@
 import argparse
 import threading
 import signal
-from collections import Mapping
+from collections.abc import Mapping
 import logging
 import os.path
 

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import object
 import argparse
 import threading
 import signal

--- a/stacker/commands/stacker/build.py
+++ b/stacker/commands/stacker/build.py
@@ -5,9 +5,6 @@ have changed for a given stack. If nothing has changed, stacker will correctly
 skip executing anything against the stack.
 
 """
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 from .base import BaseCommand, cancel
 from ...actions import build

--- a/stacker/commands/stacker/destroy.py
+++ b/stacker/commands/stacker/destroy.py
@@ -5,9 +5,6 @@ any manual requirements they specify or output values they rely on from other
 stacks.
 
 """
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from .base import BaseCommand, cancel
 from ...actions import destroy
 

--- a/stacker/commands/stacker/diff.py
+++ b/stacker/commands/stacker/diff.py
@@ -3,9 +3,6 @@
 Sometimes small changes can have big impacts.  Run "stacker diff" before
 "stacker build" to detect bad things(tm) from happening in advance!
 """
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 from .base import BaseCommand
 from ...actions import diff

--- a/stacker/commands/stacker/graph.py
+++ b/stacker/commands/stacker/graph.py
@@ -1,9 +1,6 @@
 """Prints the the relationships between steps as a graph.
 
 """
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 from .base import BaseCommand
 from ...actions import graph

--- a/stacker/commands/stacker/info.py
+++ b/stacker/commands/stacker/info.py
@@ -1,7 +1,4 @@
 """Gets information on the CloudFormation stacks based on the given config."""
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 from .base import BaseCommand
 from ...actions import info

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from past.types import basestring
-from builtins import str
 import copy
 import sys
 import logging

--- a/stacker/config/translators/__init__.py
+++ b/stacker/config/translators/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import yaml
 
 from .kms import kms_simple_constructor

--- a/stacker/config/translators/kms.py
+++ b/stacker/config/translators/kms.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # NOTE: The translator is going to be deprecated in favor of the lookup
 from ...lookups.handlers.kms import KmsLookup
 

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import object
 import collections
 import logging
 

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import logging
 
 from stacker.config import Config
@@ -189,7 +189,7 @@ class Context(object):
                 as returned from a hook.
         """
 
-        if not isinstance(data, collections.Mapping):
+        if not isinstance(data, collections.abc.Mapping):
             raise ValueError("Hook (key: %s) data must be an instance of "
                              "collections.Mapping (a dictionary for "
                              "example)." % key)

--- a/stacker/dag/__init__.py
+++ b/stacker/dag/__init__.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import object
 import collections
 import logging
 from threading import Thread

--- a/stacker/dag/__init__.py
+++ b/stacker/dag/__init__.py
@@ -1,15 +1,10 @@
-import collections
 import logging
 from threading import Thread
 from copy import copy, deepcopy
-from collections import deque
+import collections.abc
+from collections import deque, OrderedDict
 
 logger = logging.getLogger(__name__)
-
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
 
 
 class DAGValidationError(Exception):
@@ -310,7 +305,7 @@ class DAG(object):
         for new_node in graph_dict:
             self.add_node(new_node)
         for ind_node, dep_nodes in graph_dict.items():
-            if not isinstance(dep_nodes, collections.Iterable):
+            if not isinstance(dep_nodes, collections.abc.Iterable):
                 raise TypeError('%s: dict values must be lists' % ind_node)
             for dep_node in dep_nodes:
                 self.add_edge(ind_node, dep_node)

--- a/stacker/environment.py
+++ b/stacker/environment.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 import yaml
 

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 
 class InvalidConfig(Exception):

--- a/stacker/hooks/aws_lambda.py
+++ b/stacker/hooks/aws_lambda.py
@@ -1,8 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from past.builtins import basestring
 import os
 import os.path

--- a/stacker/hooks/command.py
+++ b/stacker/hooks/command.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 import logging
 import os

--- a/stacker/hooks/ecs.py
+++ b/stacker/hooks/ecs.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # A lot of this code exists to deal w/ the broken ECS connect_to_region
 # function, and will be removed once this pull request is accepted:
 #   https://github.com/boto/boto/pull/3143

--- a/stacker/hooks/iam.py
+++ b/stacker/hooks/iam.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import input
 import copy
 import logging
 

--- a/stacker/hooks/keypair.py
+++ b/stacker/hooks/keypair.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 import logging
 import os

--- a/stacker/hooks/route53.py
+++ b/stacker/hooks/route53.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import logging
 
 from stacker.session_cache import get_session

--- a/stacker/hooks/utils.py
+++ b/stacker/hooks/utils.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import collections
+import collections.abc
 import logging
 
 from stacker.util import load_object_from_string
@@ -70,7 +70,7 @@ def handle_hooks(stage, hooks, provider, context):
             logger.warning("Non-required hook %s failed. Return value: %s",
                            hook.path, result)
         else:
-            if isinstance(result, collections.Mapping):
+            if isinstance(result, collections.abc.Mapping):
                 if data_key:
                     logger.debug("Adding result for hook %s to context in "
                                  "data_key %s.", hook.path, data_key)

--- a/stacker/hooks/utils.py
+++ b/stacker/hooks/utils.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import os
 import sys
 import collections

--- a/stacker/logger/__init__.py
+++ b/stacker/logger/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import sys
 import logging
 

--- a/stacker/lookups/__init__.py
+++ b/stacker/lookups/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from past.builtins import basestring
 from collections import namedtuple
 import re

--- a/stacker/lookups/handlers/__init__.py
+++ b/stacker/lookups/handlers/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import division
 
 
 class LookupHandler(object):

--- a/stacker/lookups/handlers/ami.py
+++ b/stacker/lookups/handlers/ami.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from stacker.session_cache import get_session
 import re
 import operator

--- a/stacker/lookups/handlers/default.py
+++ b/stacker/lookups/handlers/default.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 from . import LookupHandler
 

--- a/stacker/lookups/handlers/dynamodb.py
+++ b/stacker/lookups/handlers/dynamodb.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import str
 from botocore.exceptions import ClientError
 import re
 from stacker.session_cache import get_session

--- a/stacker/lookups/handlers/envvar.py
+++ b/stacker/lookups/handlers/envvar.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import os
 
 from . import LookupHandler

--- a/stacker/lookups/handlers/file.py
+++ b/stacker/lookups/handlers/file.py
@@ -2,10 +2,7 @@
 import base64
 import json
 import re
-try:
-    from collections.abc import Mapping, Sequence
-except ImportError:
-    from collections import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 import yaml
 

--- a/stacker/lookups/handlers/file.py
+++ b/stacker/lookups/handlers/file.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import bytes, str
 
 import base64
 import json

--- a/stacker/lookups/handlers/hook_data.py
+++ b/stacker/lookups/handlers/hook_data.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 from . import LookupHandler
 

--- a/stacker/lookups/handlers/kms.py
+++ b/stacker/lookups/handlers/kms.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import codecs
 import sys
 from stacker.session_cache import get_session

--- a/stacker/lookups/handlers/output.py
+++ b/stacker/lookups/handlers/output.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 import re
 from collections import namedtuple

--- a/stacker/lookups/handlers/rxref.py
+++ b/stacker/lookups/handlers/rxref.py
@@ -11,9 +11,6 @@ Example:
         some-relative-fully-qualified-stack-name::SomeOutputName}
 
 """
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from . import LookupHandler
 from .output import deconstruct
 

--- a/stacker/lookups/handlers/split.py
+++ b/stacker/lookups/handlers/split.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from . import LookupHandler
 TYPE_NAME = "split"
 

--- a/stacker/lookups/handlers/ssmstore.py
+++ b/stacker/lookups/handlers/ssmstore.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import str
 
 from stacker.session_cache import get_session
 

--- a/stacker/lookups/handlers/xref.py
+++ b/stacker/lookups/handlers/xref.py
@@ -10,9 +10,6 @@ Example:
     conf_value: ${xref some-fully-qualified-stack-name::SomeOutputName}
 
 """
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from . import LookupHandler
 from .output import deconstruct
 

--- a/stacker/lookups/registry.py
+++ b/stacker/lookups/registry.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 import logging
 import warnings

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import object
 import os
 import logging
 import time

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -1,10 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import range
-from builtins import object
 import json
 import yaml
 import logging

--- a/stacker/providers/base.py
+++ b/stacker/providers/base.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import object
 
 
 def not_implemented(method):

--- a/stacker/session_cache.py
+++ b/stacker/session_cache.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import boto3
 import logging
 from .ui import ui

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import object
 import copy
 
 from . import util

--- a/stacker/status.py
+++ b/stacker/status.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import object
 import operator
 
 

--- a/stacker/target.py
+++ b/stacker/target.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
 
 
 class Target(object):

--- a/stacker/tests/actions/test_base.py
+++ b/stacker/tests/actions/test_base.py
@@ -1,8 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import unittest
 

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import str
 import unittest
 from collections import namedtuple
 

--- a/stacker/tests/actions/test_destroy.py
+++ b/stacker/tests/actions/test_destroy.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import object
 import unittest
 
 import mock

--- a/stacker/tests/actions/test_diff.py
+++ b/stacker/tests/actions/test_diff.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 
 from operator import attrgetter

--- a/stacker/tests/blueprints/test_base.py
+++ b/stacker/tests/blueprints/test_base.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 import sys
 from mock import patch

--- a/stacker/tests/blueprints/test_base.py
+++ b/stacker/tests/blueprints/test_base.py
@@ -70,8 +70,8 @@ class TestBlueprintRendering(unittest.TestCase):
             }
 
             def create_template(self):
-                self.template.add_version('2010-09-09')
-                self.template.add_description('TestBlueprint')
+                self.template.set_version('2010-09-09')
+                self.template.set_description('TestBlueprint')
 
         expected_json = """{
     "AWSTemplateFormatVersion": "2010-09-09",
@@ -105,8 +105,8 @@ class TestBaseBlueprint(unittest.TestCase):
             VARIABLES = {}
 
             def create_template(self):
-                self.template.add_version('2010-09-09')
-                self.template.add_description('TestBlueprint')
+                self.template.set_version('2010-09-09')
+                self.template.set_description('TestBlueprint')
                 self.add_output(output_name, output_value)
 
         bp = TestBlueprint(name="test", context=mock_context())

--- a/stacker/tests/blueprints/test_raw.py
+++ b/stacker/tests/blueprints/test_raw.py
@@ -1,7 +1,4 @@
 """Test module for blueprint-from-raw-template module."""
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import json
 import unittest
 

--- a/stacker/tests/blueprints/test_testutil.py
+++ b/stacker/tests/blueprints/test_testutil.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 
 from troposphere import ecr

--- a/stacker/tests/conftest.py
+++ b/stacker/tests/conftest.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 import logging
 import os

--- a/stacker/tests/factories.py
+++ b/stacker/tests/factories.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import object
 from mock import MagicMock
 
 from stacker.context import Context

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import range
 from troposphere import GetAtt, Output, Sub, Ref
 from troposphere import iam
 

--- a/stacker/tests/fixtures/mock_hooks.py
+++ b/stacker/tests/fixtures/mock_hooks.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 
 def mock_hook(provider, context, **kwargs):

--- a/stacker/tests/fixtures/mock_lookups.py
+++ b/stacker/tests/fixtures/mock_lookups.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 TYPE_NAME = "mock"
 
 

--- a/stacker/tests/hooks/test_aws_lambda.py
+++ b/stacker/tests/hooks/test_aws_lambda.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import range
 import os.path
 import os
 import mock

--- a/stacker/tests/hooks/test_command.py
+++ b/stacker/tests/hooks/test_command.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 import os
 import unittest

--- a/stacker/tests/hooks/test_ecs.py
+++ b/stacker/tests/hooks/test_ecs.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 
 import boto3

--- a/stacker/tests/hooks/test_iam.py
+++ b/stacker/tests/hooks/test_iam.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 
 import boto3

--- a/stacker/tests/hooks/test_keypair.py
+++ b/stacker/tests/hooks/test_keypair.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import sys
 from collections import namedtuple
 from contextlib import contextmanager

--- a/stacker/tests/lookups/handlers/test_ami.py
+++ b/stacker/tests/lookups/handlers/test_ami.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 import mock
 from botocore.stub import Stubber

--- a/stacker/tests/lookups/handlers/test_default.py
+++ b/stacker/tests/lookups/handlers/test_default.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from mock import MagicMock
 import unittest
 

--- a/stacker/tests/lookups/handlers/test_dynamodb.py
+++ b/stacker/tests/lookups/handlers/test_dynamodb.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 import mock
 from botocore.stub import Stubber

--- a/stacker/tests/lookups/handlers/test_envvar.py
+++ b/stacker/tests/lookups/handlers/test_envvar.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 from stacker.lookups.handlers.envvar import EnvvarLookup
 import os

--- a/stacker/tests/lookups/handlers/test_file.py
+++ b/stacker/tests/lookups/handlers/test_file.py
@@ -1,8 +1,5 @@
 # encoding: utf-8
 
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 import unittest
 import mock

--- a/stacker/tests/lookups/handlers/test_hook_data.py
+++ b/stacker/tests/lookups/handlers/test_hook_data.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 
 

--- a/stacker/tests/lookups/handlers/test_output.py
+++ b/stacker/tests/lookups/handlers/test_output.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from mock import MagicMock
 import unittest
 

--- a/stacker/tests/lookups/handlers/test_rxref.py
+++ b/stacker/tests/lookups/handlers/test_rxref.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from mock import MagicMock
 import unittest
 

--- a/stacker/tests/lookups/handlers/test_split.py
+++ b/stacker/tests/lookups/handlers/test_split.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 
 from stacker.lookups.handlers.split import SplitLookup

--- a/stacker/tests/lookups/handlers/test_ssmstore.py
+++ b/stacker/tests/lookups/handlers/test_ssmstore.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import str
 import unittest
 import mock
 from botocore.stub import Stubber

--- a/stacker/tests/lookups/handlers/test_xref.py
+++ b/stacker/tests/lookups/handlers/test_xref.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from mock import MagicMock
 import unittest
 

--- a/stacker/tests/lookups/test_registry.py
+++ b/stacker/tests/lookups/test_registry.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 
 from mock import MagicMock

--- a/stacker/tests/providers/aws/test_default.py
+++ b/stacker/tests/providers/aws/test_default.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import range
 import copy
 from datetime import datetime
 import os.path

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import next
 import sys
 import unittest
 import yaml

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 
 from stacker.context import Context, get_fqn

--- a/stacker/tests/test_dag.py
+++ b/stacker/tests/test_dag.py
@@ -1,7 +1,4 @@
 """ Tests on the DAG implementation """
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import threading
 
 import pytest

--- a/stacker/tests/test_environment.py
+++ b/stacker/tests/test_environment.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 
 from stacker.environment import (

--- a/stacker/tests/test_lookups.py
+++ b/stacker/tests/test_lookups.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 
 from stacker.lookups import extract_lookups, extract_lookups_from_string

--- a/stacker/tests/test_parse_user_data.py
+++ b/stacker/tests/test_parse_user_data.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 
 import yaml

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import range
 import os
 import shutil
 import tempfile

--- a/stacker/tests/test_stack.py
+++ b/stacker/tests/test_stack.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from mock import MagicMock
 import unittest
 

--- a/stacker/tests/test_stacker.py
+++ b/stacker/tests/test_stacker.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import unittest
 
 from stacker.commands import Stacker

--- a/stacker/tests/test_util.py
+++ b/stacker/tests/test_util.py
@@ -1,8 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 
 import unittest
 

--- a/stacker/tests/test_variables.py
+++ b/stacker/tests/test_variables.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 import unittest
 

--- a/stacker/tokenize_userdata.py
+++ b/stacker/tokenize_userdata.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import re
 
 from troposphere import Ref, GetAtt

--- a/stacker/ui.py
+++ b/stacker/ui.py
@@ -1,8 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import input
-from builtins import object
 import threading
 import logging
 from getpass import getpass

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -1,8 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import str
-from builtins import object
 import copy
 import uuid
 import importlib

--- a/stacker/variables.py
+++ b/stacker/variables.py
@@ -1,11 +1,7 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import division
 
 import re
 
 from past.builtins import basestring
-from builtins import object
 from string import Template
 
 from .exceptions import InvalidLookupCombination, UnresolvedVariable, \

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,7 +1,7 @@
-pytest~=4.3
+pytest~=6.0
 pytest-cov~=2.6
 mock~=2.0
 moto[awslambda,ec2]~=3.0.0
-testfixtures~=4.10.0
+testfixtures~=6.18.3
 flake8
 pep8-naming

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,0 +1,6 @@
+pytest~=4.3
+pytest-cov~=2.6
+mock~=2.0
+moto[awslambda,ec2]~=3.0.0
+testfixtures~=4.10.0
+flake8

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -4,3 +4,4 @@ mock~=2.0
 moto[awslambda,ec2]~=3.0.0
 testfixtures~=4.10.0
 flake8
+pep8-naming


### PR DESCRIPTION
Merge https://github.com/cloudtools/stacker/pull/773 into this fork of `stacker`.
