### PR TITLE
Add AppManagerCFNStackKey stack tag

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -32,7 +32,11 @@ logger = logging.getLogger(__name__)
 
 def build_stack_tags(stack):
     """Builds a common set of tags to attach to a stack"""
-    return [{'Key': t[0], 'Value': t[1]} for t in stack.tags.items()]
+    tags = [{'Key': t[0], 'Value': t[1]} for t in stack.tags.items()]
+    # By default, set the AWS Systems Manager Application Manager tag to the stack name
+    if 'AppManagerCFNStackKey' not in stack.tags:
+        tags.append({'Key': 'AppManagerCFNStackKey', 'Value': stack.fqn})
+    return tags
 
 
 def should_update(stack):


### PR DESCRIPTION
Add the `AppManagerCFNStackKey` tag to CloudFormation stacks for integration with the AWS Systems Manager Application Manager. This will allow admins to see Cost Explorer data by stack here: https://us-east-1.console.aws.amazon.com/systems-manager/appmanager/applications

The tag for each stack will be set to the fully qualified name of that stack.

Individual manifests may override this by adding something like this to the manifest yaml file at the top level:
```yaml
tags:
    AppManagerCFNStackKey: "dev"
```

This PR is equivalent to declaring the following on every stack in the manifest, assuming the namespace is passed in as an environment variable called `namespace`:
```yaml
stacks:
  - name: MyStack
    tags:
        AppManagerCFNStackKey: "${namespace}MyStack"
```

The new tag is always on. This PR does not provide a mechanism to disable it. The next deploy of each stack will update every resource to add the tag.

Ticket: https://dataworld.atlassian.net/browse/SILO-872